### PR TITLE
feat: add pluggable LSP parser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+dist/
+node_modules/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
 # doc-graphc
+
+Ferramenta de linha de comando que lê arquivos de código e gera diagramas UML no formato Mermaid. Atualmente suporta arquivos TypeScript, reconhecendo classes, interfaces, tipos e enums com seus modificadores de acesso e relacionamentos. A arquitetura permite adicionar outros parsers no futuro.
+
+O parser pode ser escolhido entre uma implementação nativa de TypeScript (baseada em ts-morph) ou um cliente genérico de Language Server Protocol (LSP), permitindo integrar servidores de linguagem externos ou versões personalizadas.
+
+## Uso
+
+```bash
+npm install
+npm run diagram -- <caminho-do-arquivo-ou-pasta>
+
+# utilizando o parser LSP
+npm run diagram -- --parser lsp <caminho-do-arquivo-ou-pasta>
+```
+
+## Testes
+
+```bash
+npm test
+```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # doc-graphc
 
-Ferramenta de linha de comando que lê arquivos de código e gera diagramas UML no formato Mermaid. Atualmente suporta arquivos TypeScript, reconhecendo classes, interfaces, tipos e enums com seus modificadores de acesso e relacionamentos. A arquitetura permite adicionar outros parsers no futuro.
+Ferramenta de linha de comando que lê arquivos de código e gera diagramas UML no formato Mermaid. Atualmente suporta arquivos TypeScript, reconhecendo classes, interfaces, tipos e enums com construtores, parâmetros, tipos de atributos, retornos de métodos, modificadores de acesso e relacionamentos. A arquitetura permite adicionar outros parsers no futuro.
 
 O parser pode ser escolhido entre uma implementação nativa de TypeScript (baseada em ts-morph) ou um cliente genérico de Language Server Protocol (LSP), permitindo integrar servidores de linguagem externos ou versões personalizadas.
 

--- a/fixtures/sample.ts
+++ b/fixtures/sample.ts
@@ -30,6 +30,10 @@ export abstract class Person implements Greeter {
     this._name = n;
   }
 
+  calculateSalary(multiplier: number): number {
+    return this.age * multiplier;
+  }
+
   abstract greet(): void;
 }
 

--- a/fixtures/sample.ts
+++ b/fixtures/sample.ts
@@ -1,0 +1,39 @@
+export interface Greeter {
+  greet(): void;
+}
+
+export type Address = {
+  street: string;
+}
+
+export enum Role {
+  Admin,
+  User
+}
+
+export abstract class Person implements Greeter {
+  protected age: number;
+  private _name: string;
+  address: Address;
+
+  constructor(name: string, age: number, address: Address) {
+    this._name = name;
+    this.age = age;
+    this.address = address;
+  }
+
+  get name() {
+    return this._name;
+  }
+
+  set name(n: string) {
+    this._name = n;
+  }
+
+  abstract greet(): void;
+}
+
+export class Employee extends Person {
+  role: Role;
+  greet() {}
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,391 @@
+{
+  "name": "doc-graphc",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "doc-graphc",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "commander": "^14.0.0",
+        "ts-morph": "^26.0.0",
+        "vscode-jsonrpc": "^8.2.0",
+        "vscode-languageserver-protocol": "^3.17.5"
+      },
+      "devDependencies": {
+        "@types/node": "^24.3.0",
+        "typescript": "^5.9.2"
+      }
+    },
+    "node_modules/@isaacs/balanced-match": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
+      "integrity": "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@isaacs/brace-expansion": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.0.tgz",
+      "integrity": "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==",
+      "license": "MIT",
+      "dependencies": {
+        "@isaacs/balanced-match": "^4.0.1"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@ts-morph/common": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.27.0.tgz",
+      "integrity": "sha512-Wf29UqxWDpc+i61k3oIOzcUfQt79PIT9y/MWfAGlrkjg6lBC1hwDECLXPVJAhWjiGbfBCxZd65F/LIZF3+jeJQ==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-glob": "^3.3.3",
+        "minimatch": "^10.0.1",
+        "path-browserify": "^1.0.1"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "24.3.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.0.tgz",
+      "integrity": "sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.10.0"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/code-block-writer": {
+      "version": "13.0.3",
+      "resolved": "https://registry.npmjs.org/code-block-writer/-/code-block-writer-13.0.3.tgz",
+      "integrity": "sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg==",
+      "license": "MIT"
+    },
+    "node_modules/commander": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.0.tgz",
+      "integrity": "sha512-2uM9rYjPvyq39NwLRqaiLtWHyDC1FvryJDa2ATTVims5YAS4PupsEQsDvP14FqhFr0P49CYDugi59xaxJlTXRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fastq": {
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
+      "integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.3.tgz",
+      "integrity": "sha512-IPZ167aShDZZUMdRk66cyQAW3qr0WzbHkPdMYa8bzZhlHhO3jALbKdxcaak7W9FfT2rZNpQuUu4Od7ILEpXSaw==",
+      "license": "ISC",
+      "dependencies": {
+        "@isaacs/brace-expansion": "^5.0.0"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+      "license": "MIT"
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/ts-morph": {
+      "version": "26.0.0",
+      "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-26.0.0.tgz",
+      "integrity": "sha512-ztMO++owQnz8c/gIENcM9XfCEzgoGphTv+nKpYNM1bgsdOVC/jRZuEBf6N+mLLDNg68Kl+GgUZfOySaRiG1/Ug==",
+      "license": "MIT",
+      "dependencies": {
+        "@ts-morph/common": "~0.27.0",
+        "code-block-writer": "^13.0.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
+      "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vscode-jsonrpc": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.1.tgz",
+      "integrity": "sha512-kdjOSJ2lLIn7r1rtrMbbNCHjyMPfRnowdKjBQ+mGq6NAW5QY2bEZC/khaC5OR8svbbjvLEaIXkOq45e2X9BIbQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/vscode-languageserver-protocol": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
+      "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
+      "license": "MIT",
+      "dependencies": {
+        "vscode-jsonrpc": "8.2.0",
+        "vscode-languageserver-types": "3.17.5"
+      }
+    },
+    "node_modules/vscode-languageserver-protocol/node_modules/vscode-jsonrpc": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
+      "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/vscode-languageserver-types": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
+      "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
+      "license": "MIT"
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "commander": "^14.0.0",
         "ts-morph": "^26.0.0",
+        "typescript-language-server": "^4.4.0",
         "vscode-jsonrpc": "^8.2.0",
         "vscode-languageserver-protocol": "^3.17.5"
       },
@@ -344,6 +345,18 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-language-server": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/typescript-language-server/-/typescript-language-server-4.4.0.tgz",
+      "integrity": "sha512-enWhplhHX7PA0q+IcKHBMpTQh9I2Bmb3L45rwnkATHMsZ7YLduyyCdOmVUWJSYZfkWaBMiKwi/e2FQo4xsKeWw==",
+      "license": "Apache-2.0",
+      "bin": {
+        "typescript-language-server": "lib/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "commander": "^14.0.0",
     "ts-morph": "^26.0.0",
+    "typescript-language-server": "^4.4.0",
     "vscode-jsonrpc": "^8.2.0",
     "vscode-languageserver-protocol": "^3.17.5"
   },

--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "doc-graphc",
+  "version": "1.0.0",
+  "description": "Generate diagrams from source code",
+  "main": "dist/index.js",
+  "type": "module",
+  "scripts": {
+    "build": "tsc",
+    "diagram": "npm run build && node dist/index.js",
+    "test": "npm run build && node --test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "commander": "^14.0.0",
+    "ts-morph": "^26.0.0",
+    "vscode-jsonrpc": "^8.2.0",
+    "vscode-languageserver-protocol": "^3.17.5"
+  },
+  "devDependencies": {
+    "@types/node": "^24.3.0",
+    "typescript": "^5.9.2"
+  }
+}

--- a/src/core/model.ts
+++ b/src/core/model.ts
@@ -1,0 +1,39 @@
+import { DocumentSymbol } from 'vscode-languageserver-protocol';
+
+export type Visibility = 'public' | 'protected' | 'private';
+
+export interface MemberInfo {
+  name: string;
+  kind: 'property' | 'method' | 'getter' | 'setter';
+  visibility: Visibility;
+}
+
+export interface RelationInfo {
+  type: 'inheritance' | 'implementation' | 'association';
+  target: string;
+}
+
+export interface EntityInfo {
+  name: string;
+  kind: 'class' | 'interface' | 'enum' | 'type';
+  isAbstract?: boolean;
+  extends?: string[];
+  implements?: string[];
+  members: MemberInfo[];
+  relations: RelationInfo[];
+}
+
+export interface Parser {
+  parse(paths: string[]): Promise<EntityInfo[]>;
+}
+
+export interface DiagramGenerator {
+  generate(entities: EntityInfo[]): string;
+}
+
+
+export interface LanguageClient {
+  initialize(rootUri: string): Promise<void>;
+  documentSymbols(filePath: string, content: string): Promise<DocumentSymbol[]>;
+  shutdown(): Promise<void>;
+}

--- a/src/core/model.ts
+++ b/src/core/model.ts
@@ -2,10 +2,18 @@ import { DocumentSymbol } from 'vscode-languageserver-protocol';
 
 export type Visibility = 'public' | 'protected' | 'private';
 
+export interface ParameterInfo {
+  name: string;
+  type: string;
+}
+
 export interface MemberInfo {
   name: string;
-  kind: 'property' | 'method' | 'getter' | 'setter';
+  kind: 'property' | 'method' | 'getter' | 'setter' | 'constructor';
   visibility: Visibility;
+  type?: string;
+  returnType?: string;
+  parameters?: ParameterInfo[];
 }
 
 export interface RelationInfo {

--- a/src/core/usecases/generateDiagram.ts
+++ b/src/core/usecases/generateDiagram.ts
@@ -1,0 +1,10 @@
+import { Parser, DiagramGenerator } from '../model.js';
+
+export class DiagramService {
+  constructor(private parser: Parser, private generator: DiagramGenerator) {}
+
+  async generateFromPaths(paths: string[]): Promise<string> {
+    const entities = await this.parser.parse(paths);
+    return this.generator.generate(entities);
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,29 @@
+import { Command } from 'commander';
+import { DiagramService } from './core/usecases/generateDiagram.js';
+import { TypeScriptParser } from './infrastructure/parsers/typescriptParser.js';
+import { MermaidDiagramGenerator } from './infrastructure/diagram/mermaidGenerator.js';
+import { LspParser } from './infrastructure/parsers/lspParser.js';
+import { StdioLanguageClient } from './infrastructure/lsp/stdioClient.js';
+
+const program = new Command();
+
+program
+  .name('doc-graphc')
+  .description('Generate diagrams from source code')
+  .argument('<path...>', 'File or directory to parse')
+  .option('--parser <parser>', 'Parser implementation to use (ts|lsp)', 'ts')
+  .action(async (paths: string[], opts) => {
+    const generator = new MermaidDiagramGenerator();
+    let parser;
+    if (opts.parser === 'lsp') {
+      const client = new StdioLanguageClient('typescript-language-server', ['--stdio']);
+      parser = new LspParser(client);
+    } else {
+      parser = new TypeScriptParser();
+    }
+    const service = new DiagramService(parser, generator);
+    const diagram = await service.generateFromPaths(paths);
+    console.log(diagram);
+  });
+
+program.parse();

--- a/src/infrastructure/diagram/mermaidGenerator.ts
+++ b/src/infrastructure/diagram/mermaidGenerator.ts
@@ -1,0 +1,47 @@
+import { DiagramGenerator, EntityInfo, RelationInfo, MemberInfo } from '../../core/model.js';
+
+function visibilitySymbol(v: MemberInfo['visibility']): string {
+  switch (v) {
+    case 'private':
+      return '-';
+    case 'protected':
+      return '#';
+    default:
+      return '+';
+  }
+}
+
+function relationLine(from: string, rel: RelationInfo): string {
+  if (rel.type === 'inheritance') {
+    return `  ${rel.target} <|-- ${from}`;
+  }
+  if (rel.type === 'implementation') {
+    return `  ${rel.target} <|.. ${from}`;
+  }
+  return `  ${from} --> ${rel.target}`;
+}
+
+export class MermaidDiagramGenerator implements DiagramGenerator {
+  generate(entities: EntityInfo[]): string {
+    const lines: string[] = ['classDiagram'];
+    for (const e of entities) {
+      lines.push(`  class ${e.name} {`);
+      if (e.kind === 'interface') lines.push('    <<interface>>');
+      if (e.kind === 'enum') lines.push('    <<enumeration>>');
+      if (e.isAbstract) lines.push('    <<abstract>>');
+      for (const m of e.members) {
+        const symbol = visibilitySymbol(m.visibility);
+        const prefix = m.kind === 'getter' ? 'get ' : m.kind === 'setter' ? 'set ' : '';
+        const suffix = m.kind === 'method' || m.kind === 'getter' || m.kind === 'setter' ? '()' : '';
+        lines.push(`    ${symbol}${prefix}${m.name}${suffix}`);
+      }
+      lines.push('  }');
+    }
+    for (const e of entities) {
+      for (const r of e.relations) {
+        lines.push(relationLine(e.name, r));
+      }
+    }
+    return lines.join('\n');
+  }
+}

--- a/src/infrastructure/diagram/mermaidGenerator.ts
+++ b/src/infrastructure/diagram/mermaidGenerator.ts
@@ -31,9 +31,18 @@ export class MermaidDiagramGenerator implements DiagramGenerator {
       if (e.isAbstract) lines.push('    <<abstract>>');
       for (const m of e.members) {
         const symbol = visibilitySymbol(m.visibility);
-        const prefix = m.kind === 'getter' ? 'get ' : m.kind === 'setter' ? 'set ' : '';
-        const suffix = m.kind === 'method' || m.kind === 'getter' || m.kind === 'setter' ? '()' : '';
-        lines.push(`    ${symbol}${prefix}${m.name}${suffix}`);
+        if (m.kind === 'constructor') {
+          const params = (m.parameters || []).map(p => `${p.name}: ${p.type}`).join(', ');
+          lines.push(`    ${symbol}${e.name}(${params})`);
+        } else if (m.kind === 'property') {
+          const type = m.type ? `: ${m.type}` : '';
+          lines.push(`    ${symbol}${m.name}${type}`);
+        } else {
+          const prefix = m.kind === 'getter' ? 'get ' : m.kind === 'setter' ? 'set ' : '';
+          const params = (m.parameters || []).map(p => `${p.name}: ${p.type}`).join(', ');
+          const returnType = m.returnType ? `: ${m.returnType}` : '';
+          lines.push(`    ${symbol}${prefix}${m.name}(${params})${returnType}`);
+        }
       }
       lines.push('  }');
     }

--- a/src/infrastructure/lsp/stdioClient.ts
+++ b/src/infrastructure/lsp/stdioClient.ts
@@ -19,9 +19,16 @@ export class StdioLanguageClient implements LanguageClient {
     const params: InitializeParams = {
       processId: process.pid,
       rootUri: pathToFileURL(rootUri).toString(),
-      capabilities: {},
+      capabilities: {
+        textDocument: {
+          documentSymbol: {
+            hierarchicalDocumentSymbolSupport: true,
+          },
+        },
+      },
     };
     await this.connection.sendRequest('initialize', params);
+    await this.connection.sendNotification('initialized', {});
   }
 
   async documentSymbols(filePath: string, content: string): Promise<DocumentSymbol[]> {

--- a/src/infrastructure/lsp/stdioClient.ts
+++ b/src/infrastructure/lsp/stdioClient.ts
@@ -1,0 +1,45 @@
+import { spawn, ChildProcess } from 'node:child_process';
+import { MessageConnection, StreamMessageReader, StreamMessageWriter, createMessageConnection } from 'vscode-jsonrpc/node.js';
+import { InitializeParams, TextDocumentItem, DocumentSymbol } from 'vscode-languageserver-protocol';
+import { LanguageClient } from '../../core/model.js';
+import { pathToFileURL } from 'node:url';
+
+export class StdioLanguageClient implements LanguageClient {
+  private proc?: ChildProcess;
+  private connection?: MessageConnection;
+
+  constructor(private command: string, private args: string[] = []) {}
+
+  async initialize(rootUri: string): Promise<void> {
+    this.proc = spawn(this.command, this.args, { stdio: 'pipe' });
+    const reader = new StreamMessageReader(this.proc.stdout!);
+    const writer = new StreamMessageWriter(this.proc.stdin!);
+    this.connection = createMessageConnection(reader, writer);
+    this.connection.listen();
+    const params: InitializeParams = {
+      processId: process.pid,
+      rootUri: pathToFileURL(rootUri).toString(),
+      capabilities: {},
+    };
+    await this.connection.sendRequest('initialize', params);
+  }
+
+  async documentSymbols(filePath: string, content: string): Promise<DocumentSymbol[]> {
+    if (!this.connection) throw new Error('LSP not initialized');
+    const uri = pathToFileURL(filePath).toString();
+    const textDoc: TextDocumentItem = {
+      uri,
+      languageId: 'typescript',
+      version: 1,
+      text: content,
+    };
+    await this.connection.sendNotification('textDocument/didOpen', { textDocument: textDoc });
+    const result = await this.connection.sendRequest('textDocument/documentSymbol', { textDocument: { uri } });
+    return (result as DocumentSymbol[]) || [];
+  }
+
+  async shutdown(): Promise<void> {
+    this.connection?.dispose();
+    this.proc?.kill();
+  }
+}

--- a/src/infrastructure/parsers/lspParser.ts
+++ b/src/infrastructure/parsers/lspParser.ts
@@ -72,12 +72,23 @@ export class LspParser implements Parser {
       return entity;
     }
     if (sym.kind === SymbolKind.Variable) {
-      return {
+      const entity: EntityInfo = {
         name: sym.name,
         kind: 'type',
         members: [],
         relations: [],
       };
+      const members: MemberInfo[] = [];
+      for (let i = sym.range.start.line + 1; i < sym.range.end.line; i++) {
+        const line = this.lineAt(lines, i).trim();
+        const m = line.match(/^([A-Za-z0-9_]+)/);
+        if (!m) continue;
+        members.push({ name: m[1], kind: 'property', visibility: 'public' });
+        const typeMatch = line.match(/:\s*([A-Za-z0-9_\.]+)/);
+        if (typeMatch) entity.relations.push({ type: 'association', target: typeMatch[1] });
+      }
+      entity.members = members;
+      return entity;
     }
     return null;
   }

--- a/src/infrastructure/parsers/lspParser.ts
+++ b/src/infrastructure/parsers/lspParser.ts
@@ -115,7 +115,7 @@ export class LspParser implements Parser {
         const parameters = this.parseParams(line);
         const returnType = kind === 'setter' ? undefined : this.parseReturn(line);
         members.push({ name: child.name, kind, visibility, parameters: parameters.length ? parameters : undefined, returnType });
-      } else if (child.kind === SymbolKind.EnumMember) {
+      } else if (child.kind === SymbolKind.EnumMember || child.kind === SymbolKind.Constant) {
         members.push({ name: child.name, kind: 'property', visibility: 'public' });
       }
     }

--- a/src/infrastructure/parsers/lspParser.ts
+++ b/src/infrastructure/parsers/lspParser.ts
@@ -1,0 +1,62 @@
+import fs from 'node:fs';
+import { Parser, EntityInfo, MemberInfo, LanguageClient } from '../../core/model.js';
+import { DocumentSymbol, SymbolKind } from 'vscode-languageserver-protocol';
+
+export class LspParser implements Parser {
+  constructor(private client: LanguageClient) {}
+
+  async parse(paths: string[]): Promise<EntityInfo[]> {
+    await this.client.initialize(process.cwd());
+    const entities: EntityInfo[] = [];
+    for (const p of paths) {
+      const content = fs.existsSync(p) ? fs.readFileSync(p, 'utf8') : '';
+      const symbols = await this.client.documentSymbols(p, content);
+      for (const sym of symbols) {
+        const ent = this.symbolToEntity(sym);
+        if (ent) entities.push(ent);
+      }
+    }
+    await this.client.shutdown();
+    return entities;
+  }
+
+  private symbolToEntity(sym: DocumentSymbol): EntityInfo | null {
+    if (sym.kind === SymbolKind.Class) {
+      return {
+        name: sym.name,
+        kind: 'class',
+        members: this.membersFrom(sym),
+        relations: [],
+      };
+    }
+    if (sym.kind === SymbolKind.Interface) {
+      return {
+        name: sym.name,
+        kind: 'interface',
+        members: this.membersFrom(sym),
+        relations: [],
+      };
+    }
+    if (sym.kind === SymbolKind.Enum) {
+      return {
+        name: sym.name,
+        kind: 'enum',
+        members: this.membersFrom(sym),
+        relations: [],
+      };
+    }
+    return null;
+  }
+
+  private membersFrom(sym: DocumentSymbol): MemberInfo[] {
+    const members: MemberInfo[] = [];
+    for (const child of sym.children || []) {
+      if (child.kind === SymbolKind.Field || child.kind === SymbolKind.Property) {
+        members.push({ name: child.name, kind: 'property', visibility: 'public' });
+      } else if (child.kind === SymbolKind.Method || child.kind === SymbolKind.Function) {
+        members.push({ name: child.name, kind: 'method', visibility: 'public' });
+      }
+    }
+    return members;
+  }
+}

--- a/src/infrastructure/parsers/typescriptParser.ts
+++ b/src/infrastructure/parsers/typescriptParser.ts
@@ -26,15 +26,18 @@ export class TypeScriptParser implements Parser {
           relations: [],
         };
         c.getProperties().forEach(p => {
-          const typeText = this.formatType(p.getType());
+          const propertyType = p.getType();
+          const typeText = this.formatType(propertyType);
           entity.members.push({
             name: p.getName(),
             kind: 'property',
             visibility: p.getScope() ?? 'public',
             type: typeText,
           });
-          const typeName = p.getType().getSymbol()?.getName();
-          if (typeName) entity.relations.push({ type: 'association', target: typeName });
+          const symbol = propertyType.getAliasSymbol() ?? propertyType.getSymbol();
+          const typeName = symbol?.getName();
+          if (typeName && !typeName.startsWith('__'))
+            entity.relations.push({ type: 'association', target: typeName });
         });
         c.getConstructors().forEach(cons => {
           const parameters: ParameterInfo[] = cons.getParameters().map(prm => ({
@@ -94,15 +97,18 @@ export class TypeScriptParser implements Parser {
           relations: [],
         };
         i.getProperties().forEach(p => {
-          const typeText = this.formatType(p.getType());
+          const propertyType = p.getType();
+          const typeText = this.formatType(propertyType);
           entity.members.push({
             name: p.getName(),
             kind: 'property',
             visibility: 'public',
             type: typeText,
           });
-          const typeName = p.getType().getSymbol()?.getName();
-          if (typeName) entity.relations.push({ type: 'association', target: typeName });
+          const symbol = propertyType.getAliasSymbol() ?? propertyType.getSymbol();
+          const typeName = symbol?.getName();
+          if (typeName && !typeName.startsWith('__'))
+            entity.relations.push({ type: 'association', target: typeName });
         });
         i.getMethods().forEach(m => {
           const parameters: ParameterInfo[] = m.getParameters().map(prm => ({

--- a/src/infrastructure/parsers/typescriptParser.ts
+++ b/src/infrastructure/parsers/typescriptParser.ts
@@ -1,0 +1,150 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { Project, SyntaxKind } from 'ts-morph';
+import { EntityInfo, Parser } from '../../core/model.js';
+
+export class TypeScriptParser implements Parser {
+  async parse(paths: string[]): Promise<EntityInfo[]> {
+    const files: string[] = [];
+    for (const p of paths) this.collectFiles(p, files);
+
+    const project = new Project();
+    project.addSourceFilesAtPaths(files);
+
+    const entities: EntityInfo[] = [];
+
+    for (const sourceFile of project.getSourceFiles()) {
+      // classes
+      for (const c of sourceFile.getClasses()) {
+        const entity: EntityInfo = {
+          name: c.getName() ?? 'Anonymous',
+          kind: 'class',
+          isAbstract: c.isAbstract(),
+          extends: c.getExtends()?.getExpression().getText() ? [c.getExtends()!.getExpression().getText()] : [],
+          implements: c.getImplements().map(i => i.getExpression().getText()),
+          members: [],
+          relations: [],
+        };
+        c.getProperties().forEach(p => {
+          entity.members.push({
+            name: p.getName(),
+            kind: 'property',
+            visibility: p.getScope() ?? 'public',
+          });
+          const typeName = p.getType().getSymbol()?.getName();
+          if (typeName) entity.relations.push({ type: 'association', target: typeName });
+        });
+        c.getMethods().forEach(m => {
+          entity.members.push({
+            name: m.getName(),
+            kind: 'method',
+            visibility: m.getScope() ?? 'public',
+          });
+        });
+        c.getGetAccessors().forEach(g => {
+          entity.members.push({
+            name: g.getName(),
+            kind: 'getter',
+            visibility: g.getScope() ?? 'public',
+          });
+        });
+        c.getSetAccessors().forEach(s => {
+          entity.members.push({
+            name: s.getName(),
+            kind: 'setter',
+            visibility: s.getScope() ?? 'public',
+          });
+        });
+        entities.push(entity);
+      }
+
+      // interfaces
+      for (const i of sourceFile.getInterfaces()) {
+        const entity: EntityInfo = {
+          name: i.getName() ?? 'Anonymous',
+          kind: 'interface',
+          extends: i.getExtends().map(e => e.getExpression().getText()),
+          members: [],
+          relations: [],
+        };
+        i.getProperties().forEach(p => {
+          entity.members.push({
+            name: p.getName(),
+            kind: 'property',
+            visibility: 'public',
+          });
+          const typeName = p.getType().getSymbol()?.getName();
+          if (typeName) entity.relations.push({ type: 'association', target: typeName });
+        });
+        i.getMethods().forEach(m => {
+          entity.members.push({
+            name: m.getName(),
+            kind: 'method',
+            visibility: 'public',
+          });
+        });
+        entities.push(entity);
+      }
+
+      // enums
+      for (const e of sourceFile.getEnums()) {
+        const entity: EntityInfo = {
+          name: e.getName() ?? 'Anonymous',
+          kind: 'enum',
+          members: [],
+          relations: [],
+        };
+        e.getMembers().forEach(m => {
+          entity.members.push({
+            name: m.getName() ?? '',
+            kind: 'property',
+            visibility: 'public',
+          });
+        });
+        entities.push(entity);
+      }
+
+      // type aliases with object literal
+      for (const t of sourceFile.getTypeAliases()) {
+        const node = t.getTypeNode();
+        if (node && node.getKind() === SyntaxKind.TypeLiteral) {
+          const entity: EntityInfo = {
+            name: t.getName(),
+            kind: 'type',
+            members: [],
+            relations: [],
+          };
+          const props = t.getType().getProperties();
+          props.forEach(sym => {
+            entity.members.push({
+              name: sym.getName(),
+              kind: 'property',
+              visibility: 'public',
+            });
+          });
+          entities.push(entity);
+        }
+      }
+    }
+
+    const names = new Set(entities.map(e => e.name));
+    for (const e of entities) {
+      if (e.extends) e.extends.forEach(parent => e.relations.push({ type: 'inheritance', target: parent }));
+      if (e.implements) e.implements.forEach(intf => e.relations.push({ type: 'implementation', target: intf }));
+      e.relations = e.relations.filter(r => names.has(r.target));
+    }
+
+    return entities;
+  }
+
+  private collectFiles(target: string, files: string[]) {
+    const stat = fs.statSync(target);
+    if (stat.isDirectory()) {
+      for (const entry of fs.readdirSync(target)) {
+        this.collectFiles(path.join(target, entry), files);
+      }
+    } else if (target.endsWith('.ts')) {
+      files.push(target);
+    }
+  }
+}

--- a/test/diagram.test.js
+++ b/test/diagram.test.js
@@ -14,5 +14,8 @@ test('generates mermaid diagram with relations and stereotypes', async () => {
   assert.ok(diagram.includes('<<interface>>'));
   assert.ok(diagram.includes('Greeter <|.. Person'));
   assert.ok(diagram.includes('Person <|-- Employee'));
-  assert.ok(diagram.includes('#age'));
+  assert.ok(diagram.includes('#age: number'));
+  assert.ok(diagram.includes('+Person(name: string, age: number, address: Address)'));
+  assert.ok(diagram.includes('+calculateSalary(multiplier: number): number'));
+  assert.ok(diagram.includes('+greet(): void'));
 });

--- a/test/diagram.test.js
+++ b/test/diagram.test.js
@@ -18,4 +18,5 @@ test('generates mermaid diagram with relations and stereotypes', async () => {
   assert.ok(diagram.includes('+Person(name: string, age: number, address: Address)'));
   assert.ok(diagram.includes('+calculateSalary(multiplier: number): number'));
   assert.ok(diagram.includes('+greet(): void'));
+  assert.ok(diagram.includes('Person --> Address'));
 });

--- a/test/diagram.test.js
+++ b/test/diagram.test.js
@@ -1,0 +1,18 @@
+import { test } from 'node:test';
+import { strict as assert } from 'node:assert';
+import path from 'node:path';
+import { DiagramService } from '../dist/core/usecases/generateDiagram.js';
+import { TypeScriptParser } from '../dist/infrastructure/parsers/typescriptParser.js';
+import { MermaidDiagramGenerator } from '../dist/infrastructure/diagram/mermaidGenerator.js';
+
+const sample = path.join('fixtures', 'sample.ts');
+
+test('generates mermaid diagram with relations and stereotypes', async () => {
+  const service = new DiagramService(new TypeScriptParser(), new MermaidDiagramGenerator());
+  const diagram = await service.generateFromPaths([sample]);
+  assert.ok(diagram.includes('classDiagram'));
+  assert.ok(diagram.includes('<<interface>>'));
+  assert.ok(diagram.includes('Greeter <|.. Person'));
+  assert.ok(diagram.includes('Person <|-- Employee'));
+  assert.ok(diagram.includes('#age'));
+});

--- a/test/lspParser.test.js
+++ b/test/lspParser.test.js
@@ -51,4 +51,7 @@ test('Stdio client parses real files with visibility and relations', async () =>
   assert.ok(employee.extends?.includes('Person'));
   assert.ok(employee.relations.some(r => r.type === 'inheritance' && r.target === 'Person'));
   assert.ok(employee.relations.some(r => r.type === 'association' && r.target === 'Role'));
+  const address = entities.find(e => e.name === 'Address');
+  assert.ok(address);
+  assert.ok(address.members.some(m => m.name === 'street'));
 });

--- a/test/lspParser.test.js
+++ b/test/lspParser.test.js
@@ -20,8 +20,15 @@ class FakeClient {
 
 test('LSP parser builds entities from document symbols', async () => {
   const parser = new LspParser(new FakeClient());
-  const entities = await parser.parse(['dummy.ts']);
+  const entities = await parser.parse(['fixtures/sample.ts']);
   assert.equal(entities.length, 1);
   assert.equal(entities[0].name, 'Foo');
   assert.equal(entities[0].members.length, 2);
+});
+
+test('LSP parser collects files from directories', async () => {
+  const parser = new LspParser(new FakeClient());
+  const entities = await parser.parse(['fixtures']);
+  assert.equal(entities.length, 1);
+  assert.equal(entities[0].name, 'Foo');
 });

--- a/test/lspParser.test.js
+++ b/test/lspParser.test.js
@@ -57,4 +57,7 @@ test('Stdio client parses real files with visibility and relations', async () =>
   const address = entities.find(e => e.name === 'Address');
   assert.ok(address);
   assert.ok(address.members.some(m => m.name === 'street'));
+  const role = entities.find(e => e.name === 'Role');
+  assert.ok(role);
+  assert.ok(role.members.some(m => m.name === 'Admin'));
 });

--- a/test/lspParser.test.js
+++ b/test/lspParser.test.js
@@ -43,8 +43,11 @@ test('Stdio client parses real files with visibility and relations', async () =>
   const person = entities.find(e => e.name === 'Person');
   assert.ok(person);
   assert.ok(person.implements?.includes('Greeter'));
-  assert.ok(person.members.some(m => m.name === 'age' && m.visibility === 'protected'));
-  assert.ok(person.members.some(m => m.name === '_name' && m.visibility === 'private'));
+  assert.ok(person.members.some(m => m.name === 'age' && m.visibility === 'protected' && m.type === 'number'));
+  assert.ok(person.members.some(m => m.name === '_name' && m.visibility === 'private' && m.type === 'string'));
+  assert.ok(person.members.some(m => m.kind === 'constructor' && m.parameters?.some(p => p.name === 'address' && p.type === 'Address')));
+  assert.ok(person.members.some(m => m.name === 'greet' && m.returnType === 'void'));
+  assert.ok(person.members.some(m => m.name === 'calculateSalary' && m.returnType === 'number' && m.parameters?.some(p => p.name === 'multiplier' && p.type === 'number')));
   assert.ok(person.relations.some(r => r.type === 'association' && r.target === 'Address'));
   const employee = entities.find(e => e.name === 'Employee');
   assert.ok(employee);

--- a/test/lspParser.test.js
+++ b/test/lspParser.test.js
@@ -2,6 +2,8 @@ import { test } from 'node:test';
 import { strict as assert } from 'node:assert';
 import { LspParser } from '../dist/infrastructure/parsers/lspParser.js';
 import { SymbolKind } from 'vscode-languageserver-types';
+import path from 'node:path';
+import { StdioLanguageClient } from '../dist/infrastructure/lsp/stdioClient.js';
 
 class FakeClient {
   async initialize() {}
@@ -31,4 +33,13 @@ test('LSP parser collects files from directories', async () => {
   const entities = await parser.parse(['fixtures']);
   assert.equal(entities.length, 1);
   assert.equal(entities[0].name, 'Foo');
+});
+
+test('Stdio client parses real files with properties', async () => {
+  const client = new StdioLanguageClient(path.join('node_modules', '.bin', 'typescript-language-server'), ['--stdio']);
+  const parser = new LspParser(client);
+  const entities = await parser.parse(['fixtures/sample.ts']);
+  const person = entities.find(e => e.name === 'Person');
+  assert.ok(person);
+  assert.ok(person.members.some(m => m.name === '_name'));
 });

--- a/test/lspParser.test.js
+++ b/test/lspParser.test.js
@@ -1,0 +1,27 @@
+import { test } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { LspParser } from '../dist/infrastructure/parsers/lspParser.js';
+import { SymbolKind } from 'vscode-languageserver-types';
+
+class FakeClient {
+  async initialize() {}
+  async documentSymbols(_p, _c) {
+    return [{
+      name: 'Foo',
+      kind: SymbolKind.Class,
+      children: [
+        { name: 'bar', kind: SymbolKind.Property },
+        { name: 'baz', kind: SymbolKind.Method },
+      ],
+    }];
+  }
+  async shutdown() {}
+}
+
+test('LSP parser builds entities from document symbols', async () => {
+  const parser = new LspParser(new FakeClient());
+  const entities = await parser.parse(['dummy.ts']);
+  assert.equal(entities.length, 1);
+  assert.equal(entities[0].name, 'Foo');
+  assert.equal(entities[0].members.length, 2);
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ES2020",
+    "moduleResolution": "node",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "types": ["node"]
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- add LanguageClient abstraction and generic LSP-based parser
- allow selecting ts-morph or LSP parser via `--parser` option
- document parser choices and LSP usage

## Testing
- `npm test`
- `npm run diagram -- fixtures/sample.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b24c8d5a2c8321942538b83bc69820